### PR TITLE
fix(job-runner): replace deprecated ssm managed instance role

### DIFF
--- a/src/runner/job-runner.ts
+++ b/src/runner/job-runner.ts
@@ -86,7 +86,7 @@ export class GitlabRunnerAutoscalingJobRunner extends Construct {
       props.role ||
       new Role(scope, `RunnersRoleFor${pascalCase(this.configuration.name!)}`, {
         assumedBy: new ServicePrincipal("ec2.amazonaws.com", {}),
-        managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2RoleforSSM")],
+        managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore")],
       });
     this.instanceProfile = new CfnInstanceProfile(
       scope,

--- a/test/runner/__snapshots__/manager.test.ts.snap
+++ b/test/runner/__snapshots__/manager.test.ts.snap
@@ -278,7 +278,7 @@ Object {
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -1061,7 +1061,7 @@ yum update -y aws-cfn-bootstrap
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },
@@ -1098,7 +1098,7 @@ yum update -y aws-cfn-bootstrap
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },
@@ -1135,7 +1135,7 @@ yum update -y aws-cfn-bootstrap
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },
@@ -2440,7 +2440,7 @@ yum update -y aws-cfn-bootstrap
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },
@@ -2477,7 +2477,7 @@ yum update -y aws-cfn-bootstrap
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/AmazonEC2RoleforSSM",
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
               ],
             ],
           },


### PR DESCRIPTION
fixes: https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/139