### PR TITLE
feat: set s3 storage authentication type to iam by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -733,6 +733,10 @@ The number of days after which the created cache objects are deleted from S3.
 
 ### CacheS3Configuration <a name="@pepperize/cdk-autoscaling-gitlab-runner.CacheS3Configuration" id="pepperizecdkautoscalinggitlabrunnercaches3configuration"></a>
 
+Define cache configuration for S3 storage.
+
+> https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnerscaches3-section
+
 #### Initializer <a name="[object Object].Initializer" id="object-objectinitializer"></a>
 
 ```typescript
@@ -746,8 +750,10 @@ const cacheS3Configuration: CacheS3Configuration = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | [`accessKey`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyaccesskey) | `string` | *No description.* |
+| [`authenticationType`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyauthenticationtype) | `string` | In GitLab 15.0 and later, explicitly set AuthenticationType to iam or access-key. |
 | [`bucketLocation`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertybucketlocation) | `string` | The name of the S3 region. |
 | [`bucketName`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertybucketname) | `string` | The name of the storage bucket where cache is stored. |
+| [`insecure`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyinsecure) | `boolean` | Set to true if the S3 service is available by HTTP. |
 | [`secretKey`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertysecretkey) | `string` | *No description.* |
 | [`serverAddress`](#pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyserveraddress) | `string` | The AWS S3 host. |
 
@@ -760,6 +766,21 @@ public readonly accessKey: string;
 ```
 
 - *Type:* `string`
+
+---
+
+##### `authenticationType`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.CacheS3Configuration.property.authenticationType" id="pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyauthenticationtype"></a>
+
+```typescript
+public readonly authenticationType: string;
+```
+
+- *Type:* `string`
+- *Default:* "iam"
+
+In GitLab 15.0 and later, explicitly set AuthenticationType to iam or access-key.
+
+> https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28171
 
 ---
 
@@ -785,6 +806,19 @@ public readonly bucketName: string;
 - *Default:* "runners-cache"
 
 The name of the storage bucket where cache is stored.
+
+---
+
+##### `insecure`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.CacheS3Configuration.property.insecure" id="pepperizecdkautoscalinggitlabrunnercaches3configurationpropertyinsecure"></a>
+
+```typescript
+public readonly insecure: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+Set to true if the S3 service is available by HTTP.
 
 ---
 

--- a/src/runner-configuration/cache-configuration.ts
+++ b/src/runner-configuration/cache-configuration.ts
@@ -4,6 +4,11 @@ export interface CacheConfiguration {
   readonly s3?: CacheS3Configuration;
 }
 
+/**
+ * Define cache configuration for S3 storage.
+ *
+ * @see https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnerscaches3-section
+ */
 export interface CacheS3Configuration {
   /**
    * The AWS S3 host.
@@ -19,6 +24,23 @@ export interface CacheS3Configuration {
    * The name of the S3 region.
    */
   readonly bucketLocation?: string;
+  /**
+   * In GitLab 15.0 and later, explicitly set AuthenticationType to iam or access-key.
+   *
+   * @see https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/common/config.go#L869
+   * @see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28171
+   *
+   * @default "iam"
+   */
+  readonly authenticationType?: CacheS3AuthType;
+  /**
+   * Set to true if the S3 service is available by HTTP.
+   *
+   * @default false
+   */
+  readonly insecure?: boolean;
   readonly accessKey?: string;
   readonly secretKey?: string;
 }
+
+export type CacheS3AuthType = "access-key" | "iam";

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -273,6 +273,7 @@ export class GitlabRunnerAutoscalingManager extends Construct {
                       serverAddress: `s3.${scope.urlSuffix}`,
                       bucketName: `${this.cacheBucket.bucketName}`,
                       bucketLocation: `${scope.region}`,
+                      authenticationType: "iam",
                     },
                   },
                 } as RunnerConfiguration;

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -371,6 +371,7 @@ token = \\"",
                       },
                       "\\"
     bucketLocation = \\"us-east-1\\"
+    authenticationType = \\"iam\\"
 
 [[runners]]
 url = \\"https://gitlab.com\\"
@@ -459,6 +460,7 @@ token = \\"",
                       },
                       "\\"
     bucketLocation = \\"us-east-1\\"
+    authenticationType = \\"iam\\"
 
 [[runners]]
 url = \\"https://gitlab.com\\"
@@ -536,6 +538,7 @@ token = \\"",
                       },
                       "\\"
     bucketLocation = \\"us-east-1\\"
+    authenticationType = \\"iam\\"
 
   [runners.docker]
   tls_verify = false
@@ -702,7 +705,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: 093c70b8ffcd1ddb
+# fingerprint: 0e9842638daa06c0
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -1864,6 +1867,7 @@ token = \\"",
                       },
                       "\\"
     bucketLocation = \\"us-east-1\\"
+    authenticationType = \\"iam\\"
 
   [runners.docker]
   tls_verify = false
@@ -1945,6 +1949,7 @@ token = \\"",
                       },
                       "\\"
     bucketLocation = \\"us-east-1\\"
+    authenticationType = \\"iam\\"
 
   [runners.docker]
   tls_verify = false
@@ -2109,7 +2114,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: b79d5b2c2a784afa
+# fingerprint: 54d26dd992f4ef64
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",


### PR DESCRIPTION
See https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/common/config.go#L876 and https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnerscaches3-section

Fixes #227