### PR TITLE
feat: install amazon-ecr-credentials-helper

### DIFF
--- a/API.md
+++ b/API.md
@@ -2052,6 +2052,7 @@ const machineConfiguration: MachineConfiguration = { ... }
 | [`machineName`](#pepperizecdkautoscalinggitlabrunnermachineconfigurationpropertymachinename) | `string` | *No description.* |
 | [`machineOptions`](#pepperizecdkautoscalinggitlabrunnermachineconfigurationpropertymachineoptions) | [`@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions`](#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions) | Docker Machine options passed to the Docker Machine driver. |
 | [`maxBuilds`](#pepperizecdkautoscalinggitlabrunnermachineconfigurationpropertymaxbuilds) | `number` | Maximum job (build) count before machine is removed. |
+| [`userData`](#pepperizecdkautoscalinggitlabrunnermachineconfigurationpropertyuserdata) | `string` | The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance. |
 
 ---
 
@@ -2137,6 +2138,21 @@ public readonly maxBuilds: number;
 - *Default:* 20
 
 Maximum job (build) count before machine is removed.
+
+---
+
+##### `userData`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.MachineConfiguration.property.userData" id="pepperizecdkautoscalinggitlabrunnermachineconfigurationpropertyuserdata"></a>
+
+```typescript
+public readonly userData: string;
+```
+
+- *Type:* `string`
+- *Default:* /etc/gitlab-runner/user_data_runners
+
+The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance.
+
+> https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,29 @@ new GitlabRunnerAutoscaling(this, "Runner", {
 See [example](https://github.com/pepperize/cdk-autoscaling-gitlab-runner-example/blob/main/src/zero-config.ts),
 [GitlabRunnerAutoscalingProps](https://github.com/pepperize/cdk-autoscaling-gitlab-runner/blob/main/API.md#@pepperize/cdk-autoscaling-gitlab-runner.GitlabRunnerAutoscalingProps)
 
+### ECR Credentials Helper
+
+By default, the GitLab [amzonec2 driver](https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go) will be configured to install the 
+[amazon-ecr-credential-helper](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-credential-helper) 
+on the runner's instances.
+
+To configure, override the default job runners environment:
+
+```typescript
+new GitlabRunnerAutoscaling(this, "Runner", {
+  runners: [
+    {
+      // ...
+       environment: [
+         "DOCKER_DRIVER=overlay2",
+         "DOCKER_TLS_CERTDIR=/certs",
+         'DOCKER_AUTH_CONFIG={"credHelpers": { "public.ecr.aws": "ecr-login", "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login" } }',
+      ],
+    },
+  ],
+});
+```
+
 ## Projen
 
 This project uses [projen](https://github.com/projen/projen) to maintain project configuration through code. Thus, the synthesized files with projen should never be manually edited (in fact, projen enforces that).

--- a/src/runner-configuration/configuration-mapper.ts
+++ b/src/runner-configuration/configuration-mapper.ts
@@ -29,7 +29,11 @@ export class ConfigurationMapper {
           limit: 10,
           outputLimit: 52428800,
           executor: "docker+machine",
-          environment: ["DOCKER_DRIVER=overlay2", "DOCKER_TLS_CERTDIR=/certs"],
+          environment: [
+            "DOCKER_DRIVER=overlay2",
+            "DOCKER_TLS_CERTDIR=/certs",
+            'DOCKER_AUTH_CONFIG={"credsStore": "ecr-login"}',
+          ],
           ...item,
           docker: {
             tlsVerify: false,

--- a/src/runner-configuration/machine-configuration.ts
+++ b/src/runner-configuration/machine-configuration.ts
@@ -42,6 +42,16 @@ export interface MachineConfiguration {
   readonly machineOptions?: MachineOptions;
 
   readonly autoscaling?: AutoscalingConfiguration[];
+
+  /**
+   * The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance.
+   *
+   * @see https://docs.gitlab.com/runner/configuration/runner_autoscale_aws/
+   * @see https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go
+   *
+   * @default /etc/gitlab-runner/user_data_runners
+   */
+  readonly userData?: string;
 }
 
 export type MachineDriver = "amazonec2" | string;

--- a/test/runner-configuration/__snapshots__/configuration-mapper.test.ts.snap
+++ b/test/runner-configuration/__snapshots__/configuration-mapper.test.ts.snap
@@ -11,7 +11,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"foo+bar\\"
 
   [runners.docker]
@@ -67,7 +71,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"foo+bar\\"
 
   [runners.docker]
@@ -115,7 +123,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"2foo+bar\\"
 
   [runners.docker]

--- a/test/runner-configuration/configuration-mapper.test.ts
+++ b/test/runner-configuration/configuration-mapper.test.ts
@@ -86,7 +86,11 @@ describe("ConfigurationMapper", () => {
       log_level: "info",
       runners: [
         {
-          environment: ["DOCKER_DRIVER=overlay2", "DOCKER_TLS_CERTDIR=/certs"],
+          environment: [
+            "DOCKER_DRIVER=overlay2",
+            "DOCKER_TLS_CERTDIR=/certs",
+            'DOCKER_AUTH_CONFIG={"credsStore": "ecr-login"}',
+          ],
           executor: "docker+machine",
           limit: 10,
           output_limit: 52428800,

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -289,7 +289,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner1\\"
 token = \\"",
                       Object {
@@ -339,7 +343,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner1",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-user-data=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -380,7 +385,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner2\\"
 token = \\"",
                       Object {
@@ -430,7 +439,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner2",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-user-data=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -471,7 +481,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner3\\"
 token = \\"",
                       Object {
@@ -521,7 +535,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner3",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-user-data=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -559,6 +574,15 @@ token = \\"",
                     ],
                   ],
                 },
+                "encoding": "plain",
+                "group": "gitlab-runner",
+                "mode": "000600",
+                "owner": "gitlab-runner",
+              },
+              "/etc/gitlab-runner/user_data_runners": Object {
+                "content": "#!/bin/bash
+[ ! -z \\"$(which apt-get)\\" ] && apt-get install -y amazon-ecr-credential-helper
+[ ! -z \\"$(which yum)\\" ] && yum install -y amazon-ecr-credential-helper",
                 "encoding": "plain",
                 "group": "gitlab-runner",
                 "mode": "000600",
@@ -711,7 +735,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: fd727e38cfcd946c
+# fingerprint: ee41375901e4a99d
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -1808,7 +1832,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"runner-one\\"
 token = \\"",
                       Object {
@@ -1850,7 +1878,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForRunnerOne",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-user-data=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -1892,7 +1921,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"runner-two\\"
 token = \\"",
                       Object {
@@ -1934,7 +1967,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForRunnerTwo",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-user-data=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -1974,6 +2008,15 @@ token = \\"",
                     ],
                   ],
                 },
+                "encoding": "plain",
+                "group": "gitlab-runner",
+                "mode": "000600",
+                "owner": "gitlab-runner",
+              },
+              "/etc/gitlab-runner/user_data_runners": Object {
+                "content": "#!/bin/bash
+[ ! -z \\"$(which apt-get)\\" ] && apt-get install -y amazon-ecr-credential-helper
+[ ! -z \\"$(which yum)\\" ] && yum install -y amazon-ecr-credential-helper",
                 "encoding": "plain",
                 "group": "gitlab-runner",
                 "mode": "000600",
@@ -2124,7 +2167,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: aa2de18ac84f92cd
+# fingerprint: 91dd03eb76ac4d14
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",


### PR DESCRIPTION
- Installs the https://github.com/awslabs/amazon-ecr-credential-helper on debian or red-hat based runner instances.
- Configures the runners' daemon to use the credential helper for all ecr registries.

See https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go

Fixes https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/271