### PR TITLE
feat: install custom ec2 key pair

### DIFF
--- a/API.md
+++ b/API.md
@@ -246,6 +246,7 @@ new GitlabRunnerAutoscalingJobRunner(scope: Stack, id: string, props: GitlabRunn
 | [`instanceType`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropertyinstancetype)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.InstanceType`](#aws-cdk-lib.aws_ec2.InstanceType) | *No description.* |
 | [`machineImage`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropertymachineimage)<span title="Required">*</span> | [`aws-cdk-lib.aws_ec2.IMachineImage`](#aws-cdk-lib.aws_ec2.IMachineImage) | *No description.* |
 | [`role`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropertyrole)<span title="Required">*</span> | [`aws-cdk-lib.aws_iam.IRole`](#aws-cdk-lib.aws_iam.IRole) | *No description.* |
+| [`keyPair`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropertykeypair) | [`aws-cdk-lib.aws_secretsmanager.ISecret`](#aws-cdk-lib.aws_secretsmanager.ISecret) | *No description.* |
 
 ---
 
@@ -296,6 +297,16 @@ public readonly role: IRole;
 ```
 
 - *Type:* [`aws-cdk-lib.aws_iam.IRole`](#aws-cdk-lib.aws_iam.IRole)
+
+---
+
+##### `keyPair`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.GitlabRunnerAutoscalingJobRunner.property.keyPair" id="pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropertykeypair"></a>
+
+```typescript
+public readonly keyPair: ISecret;
+```
+
+- *Type:* [`aws-cdk-lib.aws_secretsmanager.ISecret`](#aws-cdk-lib.aws_secretsmanager.ISecret)
 
 ---
 
@@ -1537,6 +1548,7 @@ const gitlabRunnerAutoscalingJobRunnerProps: GitlabRunnerAutoscalingJobRunnerPro
 | [`configuration`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertyconfiguration)<span title="Required">*</span> | [`@pepperize/cdk-autoscaling-gitlab-runner.RunnerConfiguration`](#@pepperize/cdk-autoscaling-gitlab-runner.RunnerConfiguration) | The runner EC2 instances configuration. |
 | [`token`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertytoken)<span title="Required">*</span> | [`aws-cdk-lib.aws_ssm.IStringParameter`](#aws-cdk-lib.aws_ssm.IStringParameter) | The runner’s authentication token, which is obtained during runner registration. |
 | [`instanceType`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertyinstancetype) | [`aws-cdk-lib.aws_ec2.InstanceType`](#aws-cdk-lib.aws_ec2.InstanceType) | Instance type for runner EC2 instances. |
+| [`keyPair`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertykeypair) | [`aws-cdk-lib.aws_secretsmanager.ISecret`](#aws-cdk-lib.aws_secretsmanager.ISecret) | Optionally pass a custom EC2 KeyPair, that will be used by the manager to connect to the job runner instances. |
 | [`machineImage`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertymachineimage) | [`aws-cdk-lib.aws_ec2.IMachineImage`](#aws-cdk-lib.aws_ec2.IMachineImage) | An Amazon Machine Image ID for the Runners EC2 instances. |
 | [`role`](#pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertyrole) | [`aws-cdk-lib.aws_iam.IRole`](#aws-cdk-lib.aws_iam.IRole) | Optionally pass an IAM role, that get's assigned to the EC2 runner instances via Instance Profile. |
 
@@ -1586,6 +1598,20 @@ public readonly instanceType: InstanceType;
 Instance type for runner EC2 instances.
 
 It's a combination of a class and size.
+
+---
+
+##### `keyPair`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.GitlabRunnerAutoscalingJobRunnerProps.property.keyPair" id="pepperizecdkautoscalinggitlabrunnergitlabrunnerautoscalingjobrunnerpropspropertykeypair"></a>
+
+```typescript
+public readonly keyPair: ISecret;
+```
+
+- *Type:* [`aws-cdk-lib.aws_secretsmanager.ISecret`](#aws-cdk-lib.aws_secretsmanager.ISecret)
+
+Optionally pass a custom EC2 KeyPair, that will be used by the manager to connect to the job runner instances.
+
+<ol>    <li>Example: <b>aws secretsmanager create-secret --name AnyKeyPairSecret --secret-string "{\"theKeyPairName\":\"<the private key>\",\"theKeyPairName.pub\":\"<the public key>\"}"</b></li>    <li><b>Additionally configure an unique key pair configuration.machine.machineOptions.keypairName</b></li> </ol>
 
 ---
 
@@ -2169,6 +2195,7 @@ const machineOptions: MachineOptions = { ... }
 | [`rootSize`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertyrootsize) | `number` | The root disk size of the instance (in GB). |
 | [`securityGroup`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertysecuritygroup) | `string` | The SecurityGroup's GroupName, not the GroupId. |
 | [`spotPrice`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertyspotprice) | `number` | The amazonec2-spot-price parameter. |
+| [`sshKeypath`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertysshkeypath) | `string` | The amazonec2-ssh-keypath parameter. |
 | [`subnetId`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertysubnetid) | `string` | *No description.* |
 | [`useEbsOptimizedInstance`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertyuseebsoptimizedinstance) | `boolean` | Create an EBS Optimized Instance, instance type must support it. |
 | [`usePrivateAddress`](#pepperizecdkautoscalinggitlabrunnermachineoptionspropertyuseprivateaddress) | `boolean` | Use the private IP address of Docker Machines, but still create a public IP address. |
@@ -2234,7 +2261,7 @@ public readonly keypairName: string;
 
 The amazonec2-keypair-name parameter.
 
-A set of security credentials that you use to prove your identity when connecting to an Amazon EC2 instance.
+A set of security credentials that you use to prove your identity when connecting to an Amazon EC2 instance.  <b>using --amazonec2-keypair-name also requires --amazonec2-ssh-keypath</b>
 
 > https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go#L398
 
@@ -2352,6 +2379,19 @@ The amazonec2-spot-price parameter.
 The bidding price for spot instances.
 
 > https://aws.amazon.com/ec2/spot/pricing/
+
+---
+
+##### `sshKeypath`<sup>Optional</sup> <a name="@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.sshKeypath" id="pepperizecdkautoscalinggitlabrunnermachineoptionspropertysshkeypath"></a>
+
+```typescript
+public readonly sshKeypath: string;
+```
+
+- *Type:* `string`
+- *Default:* /etc/gitlab-runner/ssh
+
+The amazonec2-ssh-keypath parameter.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ new GitlabRunnerAutoscaling(this, "Runner", {
 See [example](https://github.com/pepperize/cdk-autoscaling-gitlab-runner-example/blob/main/src/cache.ts),
 [GitlabRunnerAutoscalingCacheProps](https://github.com/pepperize/cdk-autoscaling-gitlab-runner/blob/main/API.md#gitlabrunnerautoscalingcacheprops-)
 
+### Custom EC2 key pair
+
+By default, the [amazonec2](https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go) driver will create an EC2 key pair for each runner. To use custom ssh credentials provide a SecretsManager Secret with the private and public key file:
+
+```shell
+aws secretsmanager create-secret --name CustomEC2KeyPair --secret-string "{\"theKeyPairName\":\"<the private key>\",\"theKeyPairName.pub\":\"<the public key>\"}"
+```
+
+```typescript
+const keyPair = Secret.fromSecretNameV2(stack, "Secret", "CustomEC2KeyPair")
+
+new GitlabRunnerAutoscaling(this, "Runner", {
+  runners: [
+    {
+      keyPair: keyPair,
+       configuration: {
+        machine: {
+          machineOptions: {
+            keypairName: "theKeyPairName",
+          },
+        },
+       },
+    },
+  ],
+  cache: { bucket: cache },
+});
+```
+
 ### Configure Docker Machine
 
 By default, docker machine is configured to run privileged with `CAP_SYS_ADMIN` to support [Docker-in-Docker using the OverlayFS driver](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-the-overlayfs-driver)

--- a/src/runner-configuration/machine-options.ts
+++ b/src/runner-configuration/machine-options.ts
@@ -58,7 +58,16 @@ export interface MachineOptions {
    */
   readonly rootSize?: number;
   /**
+   * The amazonec2-ssh-keypath parameter.
+   *
+   * @default /etc/gitlab-runner/ssh
+   */
+  readonly sshKeypath?: string;
+  /**
    * The amazonec2-keypair-name parameter. A set of security credentials that you use to prove your identity when connecting to an Amazon EC2 instance.
+   *
+   * <b>using --amazonec2-keypair-name also requires --amazonec2-ssh-keypath</b>
+   *
    * @see https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go#L398
    */
   readonly keypairName?: string;

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -273,6 +273,11 @@ Object {
       "Metadata": Object {
         "AWS::CloudFormation::Init": Object {
           "config": Object {
+            "commands": Object {
+              "999-retrieve-ec2-key-pair": Object {
+                "command": "",
+              },
+            },
             "files": Object {
               "/etc/gitlab-runner/config.toml": Object {
                 "content": Object {
@@ -311,6 +316,7 @@ token = \\"",
   \\"amazonec2-spot-price=0.03\\",
   \\"amazonec2-metadata-token=required\\",
   \\"amazonec2-metadata-token-response-hop-limit=2\\",
+  \\"amazonec2-ssh-keypath=/etc/gitlab-runner/ssh\\",
   \\"amazonec2-instance-type=t3.medium\\",
   \\"amazonec2-ami=ami-1234\\",
   \\"amazonec2-region=us-east-1\\",
@@ -402,6 +408,7 @@ token = \\"",
   \\"amazonec2-spot-price=0.03\\",
   \\"amazonec2-metadata-token=required\\",
   \\"amazonec2-metadata-token-response-hop-limit=2\\",
+  \\"amazonec2-ssh-keypath=/etc/gitlab-runner/ssh\\",
   \\"amazonec2-instance-type=t3.small\\",
   \\"amazonec2-ami=ami-1234\\",
   \\"amazonec2-region=us-east-1\\",
@@ -493,6 +500,7 @@ token = \\"",
   \\"amazonec2-spot-price=0.03\\",
   \\"amazonec2-metadata-token=required\\",
   \\"amazonec2-metadata-token-response-hop-limit=2\\",
+  \\"amazonec2-ssh-keypath=/etc/gitlab-runner/ssh\\",
   \\"amazonec2-instance-type=t3.xlarge\\",
   \\"amazonec2-ami=ami-1234\\",
   \\"amazonec2-region=us-east-1\\",
@@ -612,6 +620,7 @@ token = \\"",
               "yum": Object {
                 "docker": Array [],
                 "gitlab-runner": Array [],
+                "jq": Array [],
                 "tzdata": Array [],
               },
             },
@@ -711,7 +720,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: fd727e38cfcd946c
+# fingerprint: a205a4162d96ae77
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -1792,6 +1801,11 @@ Object {
       "Metadata": Object {
         "AWS::CloudFormation::Init": Object {
           "config": Object {
+            "commands": Object {
+              "999-retrieve-ec2-key-pair": Object {
+                "command": "",
+              },
+            },
             "files": Object {
               "/etc/gitlab-runner/config.toml": Object {
                 "content": Object {
@@ -1830,6 +1844,7 @@ token = \\"",
   \\"amazonec2-spot-price=0.03\\",
   \\"amazonec2-metadata-token=required\\",
   \\"amazonec2-metadata-token-response-hop-limit=2\\",
+  \\"amazonec2-ssh-keypath=/etc/gitlab-runner/ssh\\",
   \\"amazonec2-instance-type=t3.micro\\",
   \\"amazonec2-ami=ami-1234\\",
   \\"amazonec2-region=us-east-1\\",
@@ -1914,6 +1929,7 @@ token = \\"",
   \\"amazonec2-spot-price=0.03\\",
   \\"amazonec2-metadata-token=required\\",
   \\"amazonec2-metadata-token-response-hop-limit=2\\",
+  \\"amazonec2-ssh-keypath=/etc/gitlab-runner/ssh\\",
   \\"amazonec2-instance-type=t3.micro\\",
   \\"amazonec2-ami=ami-1234\\",
   \\"amazonec2-region=us-east-1\\",
@@ -2027,6 +2043,7 @@ token = \\"",
               "yum": Object {
                 "docker": Array [],
                 "gitlab-runner": Array [],
+                "jq": Array [],
                 "tzdata": Array [],
               },
             },
@@ -2124,7 +2141,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: aa2de18ac84f92cd
+# fingerprint: 36cfa3f6c5414c72
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",


### PR DESCRIPTION
Use custom EC2 Key Pair for the amazonec2 driver to connect from manager to runner

https://docs.gitlab.com/runner/configuration/runner_autoscale_aws/#the-runnersmachine-section

Fixes https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/236