### PR TITLE
feat: install amazon-ecr-credentials-helper

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -53,7 +53,7 @@ const project = new AwsCdkConstructLibrary({
   },
 });
 
-project.addDevDeps("npm-check-updates@^15.3.3")
+project.addDevDeps("npm-check-updates@^15.3.3");
 
 project.tasks.tryFind("package:python")?.prependExec("pip3 install packaging");
 

--- a/API.md
+++ b/API.md
@@ -2501,6 +2501,7 @@ const machineOptions: MachineOptions = { ... }
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.subnetId">subnetId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.useEbsOptimizedInstance">useEbsOptimizedInstance</a></code> | <code>boolean</code> | Create an EBS Optimized Instance, instance type must support it. |
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.usePrivateAddress">usePrivateAddress</a></code> | <code>boolean</code> | Use the private IP address of Docker Machines, but still create a public IP address. |
+| <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.userdata">userdata</a></code> | <code>string</code> | The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance. |
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.volumeType">volumeType</a></code> | <code>string</code> | The Amazon EBS volume type to be attached to the instance. |
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.vpcId">vpcId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.zone">zone</a></code> | <code>string</code> | Extract the availabilityZone last character for the needs of gitlab configuration. |
@@ -2734,6 +2735,21 @@ Use the private IP address of Docker Machines, but still create a public IP addr
 Useful to keep the traffic internal and avoid extra costs.
 
 > [https://docs.gitlab.com/runner/configuration/runner_autoscale_aws/#the-runnersmachine-section](https://docs.gitlab.com/runner/configuration/runner_autoscale_aws/#the-runnersmachine-section)
+
+---
+
+##### `userdata`<sup>Optional</sup> <a name="userdata" id="@pepperize/cdk-autoscaling-gitlab-runner.MachineOptions.property.userdata"></a>
+
+```typescript
+public readonly userdata: string;
+```
+
+- *Type:* string
+- *Default:* /etc/gitlab-runner/user_data_runners
+
+The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance.
+
+> [https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go](https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -559,6 +559,29 @@ new GitlabRunnerAutoscaling(this, "Runner", {
 See [example](https://github.com/pepperize/cdk-autoscaling-gitlab-runner-example/blob/main/src/zero-config.ts),
 [GitlabRunnerAutoscalingProps](https://github.com/pepperize/cdk-autoscaling-gitlab-runner/blob/main/API.md#@pepperize/cdk-autoscaling-gitlab-runner.GitlabRunnerAutoscalingProps)
 
+### ECR Credentials Helper
+
+By default, the GitLab [amzonec2 driver](https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go) will be configured to install the 
+[amazon-ecr-credential-helper](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-credential-helper) 
+on the runner's instances.
+
+To configure, override the default job runners environment:
+
+```typescript
+new GitlabRunnerAutoscaling(this, "Runner", {
+  runners: [
+    {
+      // ...
+       environment: [
+         "DOCKER_DRIVER=overlay2",
+         "DOCKER_TLS_CERTDIR=/certs",
+         'DOCKER_AUTH_CONFIG={"credHelpers": { "public.ecr.aws": "ecr-login", "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login" } }',
+      ],
+    },
+  ],
+});
+```
+
 ## Projen
 
 This project uses [projen](https://github.com/projen/projen) to maintain project configuration through code. Thus, the synthesized files with projen should never be manually edited (in fact, projen enforces that).

--- a/src/runner-configuration/configuration-mapper.ts
+++ b/src/runner-configuration/configuration-mapper.ts
@@ -29,7 +29,11 @@ export class ConfigurationMapper {
           limit: 10,
           outputLimit: 52428800,
           executor: "docker+machine",
-          environment: ["DOCKER_DRIVER=overlay2", "DOCKER_TLS_CERTDIR=/certs"],
+          environment: [
+            "DOCKER_DRIVER=overlay2",
+            "DOCKER_TLS_CERTDIR=/certs",
+            'DOCKER_AUTH_CONFIG={"credsStore": "ecr-login"}',
+          ],
           ...item,
           docker: {
             tlsVerify: false,

--- a/src/runner-configuration/machine-options.ts
+++ b/src/runner-configuration/machine-options.ts
@@ -91,4 +91,13 @@ export interface MachineOptions {
    * @default 2
    */
   readonly metadataTokenResponseHopLimit?: number;
+  /**
+   * The path of the runner machine's userdata file on the manager instance used by the amazonec2 driver to create a new instance.
+   *
+   * @see https://docs.gitlab.com/runner/configuration/runner_autoscale_aws/
+   * @see https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go
+   *
+   * @default /etc/gitlab-runner/user_data_runners
+   */
+  readonly userdata?: string;
 }

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -205,6 +205,13 @@ export class GitlabRunnerAutoscalingManager extends Construct {
       `yum update -y aws-cfn-bootstrap` // !/bin/bash -xe
     );
 
+    // https://github.com/awslabs/amazon-ecr-credential-helper
+    const userDataRunners = UserData.forLinux({});
+    userDataRunners.addCommands(
+      `[ ! -z "$(which apt-get)" ] && apt-get install -y amazon-ecr-credential-helper`,
+      `[ ! -z "$(which yum)" ] && yum install -y amazon-ecr-credential-helper`
+    );
+
     const gitlabRunnerConfigRestartHandle = new InitServiceRestartHandle();
     gitlabRunnerConfigRestartHandle._addFile("/etc/gitlab-runner/config.toml");
 
@@ -270,6 +277,7 @@ export class GitlabRunnerAutoscalingManager extends Construct {
                         configuration.machine?.machineOptions?.privateAddressOnly ?? this.network.hasPrivateSubnets(),
                       usePrivateAddress: configuration.machine?.machineOptions?.usePrivateAddress ?? true,
                       iamInstanceProfile: runner.instanceProfile.ref,
+                      userdata: "/etc/gitlab-runner/user_data_runners",
                     },
                   },
                   cache: {
@@ -335,6 +343,11 @@ export class GitlabRunnerAutoscalingManager extends Construct {
               key: "999-retrieve-ec2-key-pair",
             }
           ),
+          InitFile.fromString("/etc/gitlab-runner/user_data_runners", userDataRunners.render(), {
+            owner: "gitlab-runner",
+            group: "gitlab-runner",
+            mode: "000600",
+          }),
         ]),
         [RESTART]: new InitConfig([
           InitCommand.shellCommand("gitlab-runner restart", {

--- a/test/runner-configuration/__snapshots__/configuration-mapper.test.ts.snap
+++ b/test/runner-configuration/__snapshots__/configuration-mapper.test.ts.snap
@@ -11,7 +11,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"foo+bar\\"
 
   [runners.docker]
@@ -67,7 +71,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"foo+bar\\"
 
   [runners.docker]
@@ -115,7 +123,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 token = \\"2foo+bar\\"
 
   [runners.docker]

--- a/test/runner-configuration/configuration-mapper.test.ts
+++ b/test/runner-configuration/configuration-mapper.test.ts
@@ -86,7 +86,11 @@ describe("ConfigurationMapper", () => {
       log_level: "info",
       runners: [
         {
-          environment: ["DOCKER_DRIVER=overlay2", "DOCKER_TLS_CERTDIR=/certs"],
+          environment: [
+            "DOCKER_DRIVER=overlay2",
+            "DOCKER_TLS_CERTDIR=/certs",
+            'DOCKER_AUTH_CONFIG={"credsStore": "ecr-login"}',
+          ],
           executor: "docker+machine",
           limit: 10,
           output_limit: 52428800,

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -294,7 +294,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner1\\"
 token = \\"",
                       Object {
@@ -345,7 +349,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner1",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-userdata=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -386,7 +391,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner2\\"
 token = \\"",
                       Object {
@@ -437,7 +446,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner2",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-userdata=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -478,7 +488,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"gitlab-runner3\\"
 token = \\"",
                       Object {
@@ -529,7 +543,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForGitlabRunner3",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-userdata=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -567,6 +582,15 @@ token = \\"",
                     ],
                   ],
                 },
+                "encoding": "plain",
+                "group": "gitlab-runner",
+                "mode": "000600",
+                "owner": "gitlab-runner",
+              },
+              "/etc/gitlab-runner/user_data_runners": Object {
+                "content": "#!/bin/bash
+[ ! -z \\"$(which apt-get)\\" ] && apt-get install -y amazon-ecr-credential-helper
+[ ! -z \\"$(which yum)\\" ] && yum install -y amazon-ecr-credential-helper",
                 "encoding": "plain",
                 "group": "gitlab-runner",
                 "mode": "000600",
@@ -720,7 +744,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: 6f56ce28e78e2660
+# fingerprint: d1a6225a46fa9f0e
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -1887,7 +1911,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"runner-one\\"
 token = \\"",
                       Object {
@@ -1930,7 +1958,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForRunnerOne",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-userdata=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -1972,7 +2001,11 @@ url = \\"https://gitlab.com\\"
 limit = 10
 output_limit = 52_428_800
 executor = \\"docker+machine\\"
-environment = [ \\"DOCKER_DRIVER=overlay2\\", \\"DOCKER_TLS_CERTDIR=/certs\\" ]
+environment = [
+  \\"DOCKER_DRIVER=overlay2\\",
+  \\"DOCKER_TLS_CERTDIR=/certs\\",
+  \\"DOCKER_AUTH_CONFIG={\\\\\\"credsStore\\\\\\": \\\\\\"ecr-login\\\\\\"}\\"
+]
 name = \\"runner-two\\"
 token = \\"",
                       Object {
@@ -2015,7 +2048,8 @@ token = \\"",
                       Object {
                         "Ref": "RunnersInstanceProfileForRunnerTwo",
                       },
-                      "\\"
+                      "\\",
+  \\"amazonec2-userdata=/etc/gitlab-runner/user_data_runners\\"
 ]
 
     [[runners.machine.autoscaling]]
@@ -2055,6 +2089,15 @@ token = \\"",
                     ],
                   ],
                 },
+                "encoding": "plain",
+                "group": "gitlab-runner",
+                "mode": "000600",
+                "owner": "gitlab-runner",
+              },
+              "/etc/gitlab-runner/user_data_runners": Object {
+                "content": "#!/bin/bash
+[ ! -z \\"$(which apt-get)\\" ] && apt-get install -y amazon-ecr-credential-helper
+[ ! -z \\"$(which yum)\\" ] && yum install -y amazon-ecr-credential-helper",
                 "encoding": "plain",
                 "group": "gitlab-runner",
                 "mode": "000600",
@@ -2206,7 +2249,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
-# fingerprint: 88081e1e06f4ef9a
+# fingerprint: 97f81ce72f78662d
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",


### PR DESCRIPTION
- Installs the https://github.com/awslabs/amazon-ecr-credential-helper on debian or red-hat based runner instances.
- Configures the runners' daemon to use the credential helper for all ecr registries.

See https://gitlab.com/gitlab-org/ci-cd/docker-machine/-/blob/main/drivers/amazonec2/amazonec2.go

Fixes https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/271