### PR TITLE
fix: security group name

### DIFF
--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -138,9 +138,7 @@ export class GitlabRunnerAutoscaling extends Construct {
     /**
      * Security groups
      */
-    const runnersSecurityGroupName = `${scope.stackName}-RunnersSecurityGroup`;
     const runnersSecurityGroup = new SecurityGroup(scope, "RunnersSecurityGroup", {
-      securityGroupName: runnersSecurityGroupName,
       description: "Security group for GitLab Runners.",
       vpc: this.network.vpc,
     });

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -1200,7 +1200,6 @@ yum update -y aws-cfn-bootstrap
     "RunnersSecurityGroup2A22C282": Object {
       "Properties": Object {
         "GroupDescription": "Security group for GitLab Runners.",
-        "GroupName": "MockStack-RunnersSecurityGroup",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",
@@ -2645,7 +2644,6 @@ yum update -y aws-cfn-bootstrap
     "RunnersSecurityGroup2A22C282": Object {
       "Properties": Object {
         "GroupDescription": "Security group for GitLab Runners.",
-        "GroupName": "MockStack-RunnersSecurityGroup",
         "SecurityGroupEgress": Array [
           Object {
             "CidrIp": "0.0.0.0/0",


### PR DESCRIPTION
will be managed by cfn to avoid naming collision due to multiple construct deployments in same account

https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/374

Fixes #