### PR TITLE
fix: add ecr login manager

### DIFF
--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -206,8 +206,11 @@ export class GitlabRunnerAutoscalingManager extends Construct {
 
     this.userData = UserData.forLinux({});
     this.userData.addCommands(
-      `yum update -y aws-cfn-bootstrap` // !/bin/bash -xe
+      `yum update -y aws-cfn-bootstrap`, // !/bin/bash -xe
+      `yum install -y amazon-ecr-credential-helper`
     );
+
+    const addEcrCommands 
 
     // https://github.com/awslabs/amazon-ecr-credential-helper
     const userDataRunners = UserData.forLinux({});

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -201,6 +201,16 @@ export class GitlabRunnerAutoscalingManager extends Construct {
               },
             ],
           }),
+          ECRLogin: PolicyDocument.fromJson({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: ["ecr:BatchGetImage", "ecr:GetAuthorizationToken", "ecr:GetDownloadUrlForLayer"],
+                Resource: "*"
+              }
+            ]
+          }),
         },
       });
 
@@ -209,8 +219,6 @@ export class GitlabRunnerAutoscalingManager extends Construct {
       `yum update -y aws-cfn-bootstrap`, // !/bin/bash -xe
       `yum install -y amazon-ecr-credential-helper`
     );
-
-    const addEcrCommands 
 
     // https://github.com/awslabs/amazon-ecr-credential-helper
     const userDataRunners = UserData.forLinux({});


### PR DESCRIPTION
Fixes #698 

I found that installing the `amazon-ecr-credentials-helper` on the `Manager` is what fixes the `ecr-login` issues I faced for a few head-scratching days.   But in the end it makes sense, the Manager, as far as I understand this infrastructure is doing the logging in to get an authorization token as part of the `ecr-login` flow and then passing that along to the Runner.

I'm not entirely sure how or if I need to modify tests but I'm glad to take any guidance or help.