### PR TITLE
fix: blsmth add ecr login manager

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Pepperize UG (haftungsbeschränkt)
+Copyright (c) 2024 Pepperize UG (haftungsbeschränkt)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -206,8 +206,11 @@ export class GitlabRunnerAutoscalingManager extends Construct {
 
     this.userData = UserData.forLinux({});
     this.userData.addCommands(
-      `yum update -y aws-cfn-bootstrap` // !/bin/bash -xe
+      `yum update -y aws-cfn-bootstrap`, // !/bin/bash -xe
+      `yum install -y amazon-ecr-credential-helper`
     );
+
+    const addEcrCommands 
 
     // https://github.com/awslabs/amazon-ecr-credential-helper
     const userDataRunners = UserData.forLinux({});

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -201,6 +201,16 @@ export class GitlabRunnerAutoscalingManager extends Construct {
               },
             ],
           }),
+          ECRLogin: PolicyDocument.fromJson({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: ["ecr:BatchGetImage", "ecr:GetAuthorizationToken", "ecr:GetDownloadUrlForLayer"],
+                Resource: "*"
+              }
+            ]
+          }),
         },
       });
 
@@ -209,8 +219,6 @@ export class GitlabRunnerAutoscalingManager extends Construct {
       `yum update -y aws-cfn-bootstrap`, // !/bin/bash -xe
       `yum install -y amazon-ecr-credential-helper`
     );
-
-    const addEcrCommands 
 
     // https://github.com/awslabs/amazon-ecr-credential-helper
     const userDataRunners = UserData.forLinux({});

--- a/src/runner/manager.ts
+++ b/src/runner/manager.ts
@@ -207,9 +207,9 @@ export class GitlabRunnerAutoscalingManager extends Construct {
               {
                 Effect: "Allow",
                 Action: ["ecr:BatchGetImage", "ecr:GetAuthorizationToken", "ecr:GetDownloadUrlForLayer"],
-                Resource: "*"
-              }
-            ]
+                Resource: "*",
+              },
+            ],
           }),
         },
       });

--- a/test/runner/__snapshots__/manager.test.ts.snap
+++ b/test/runner/__snapshots__/manager.test.ts.snap
@@ -238,6 +238,23 @@ Object {
             },
             "PolicyName": "Runners",
           },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "ECRLogin",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",

--- a/test/runner/__snapshots__/runner.test.ts.snap
+++ b/test/runner/__snapshots__/runner.test.ts.snap
@@ -553,6 +553,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
+yum install -y amazon-ecr-credential-helper
 # fingerprint: f928611447f57f37
 (
   set +e
@@ -753,6 +754,23 @@ yum update -y aws-cfn-bootstrap
               "Version": "2012-10-17",
             },
             "PolicyName": "Runners",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "ECRLogin",
           },
         ],
       },
@@ -1761,6 +1779,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
+yum install -y amazon-ecr-credential-helper
 # fingerprint: 8d35c76383269b1a
 (
   set +e
@@ -1961,6 +1980,23 @@ yum update -y aws-cfn-bootstrap
               "Version": "2012-10-17",
             },
             "PolicyName": "Runners",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "ECRLogin",
           },
         ],
       },
@@ -3325,6 +3361,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
+yum install -y amazon-ecr-credential-helper
 # fingerprint: 7a9eacc3e399a1c8
 (
   set +e
@@ -3527,6 +3564,23 @@ yum update -y aws-cfn-bootstrap
               "Version": "2012-10-17",
             },
             "PolicyName": "Runners",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "ECRLogin",
           },
         ],
       },
@@ -4872,6 +4926,7 @@ token = \\"",
               Array [
                 "#!/bin/bash
 yum update -y aws-cfn-bootstrap
+yum install -y amazon-ecr-credential-helper
 # fingerprint: fe8cb4550968c746
 (
   set +e
@@ -5063,6 +5118,23 @@ yum update -y aws-cfn-bootstrap
               "Version": "2012-10-17",
             },
             "PolicyName": "Runners",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                    "ecr:GetDownloadUrlForLayer",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "ECRLogin",
           },
         ],
       },


### PR DESCRIPTION
Fixes https://github.com/pepperize/cdk-autoscaling-gitlab-runner/issues/698

> I found that installing the amazon-ecr-credentials-helper on the Manager is what fixes the ecr-login issues I faced for a few head-scratching days. But in the end it makes sense, the Manager, as far as I understand this infrastructure is doing the logging in to get an authorization token as part of the ecr-login flow and then passing that along to the Runner.
> 
> I'm not entirely sure how or if I need to modify tests but I'm glad to take any guidance or help.

https://github.com/pepperize/cdk-autoscaling-gitlab-runner/pull/765